### PR TITLE
Build: remove slashes after DESTDIR from commands in uninstall target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install: all
 	install -D -m 644 ${PROG}.1 ${DESTDIR}${MANPREFIX}/man1/${PROG}.1
 
 uninstall:
-	rm -f ${DESTDIR}/${PREFIX}/bin/${PROG}
-	rm -f ${DESTDIR}/${MANPREFIX}/man1/${PROG}.1
+	rm -f ${DESTDIR}${PREFIX}/bin/${PROG}
+	rm -f ${DESTDIR}${MANPREFIX}/man1/${PROG}.1
 
 .PHONY: all clean install uninstall


### PR DESCRIPTION
It was not coherent with the `install` target: if the user sets a `DESTDIR` without a `/` at the end, the program will get installed in one path and get uninstalled from another (effectively, not uninstalling the program). This could, potentially, also remove files that shouldn't be removed, by accident. 