### PR TITLE
Replace install -D with mkdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,10 @@ clean:
 	-rm ${OBJS} ${PROG}
 
 install: all
-	install -D -m 755 ${PROG} ${DESTDIR}${PREFIX}/bin/${PROG}
-	install -D -m 644 ${PROG}.1 ${DESTDIR}${MANPREFIX}/man1/${PROG}.1
+	mkdir -p ${DESTDIR}${PREFIX}/bin
+	install -m 755 ${PROG} ${DESTDIR}${PREFIX}/bin/${PROG}
+	mkdir -p ${DESTDIR}${MANPREFIX}/man1
+	install -m 644 ${PROG}.1 ${DESTDIR}${MANPREFIX}/man1/${PROG}.1
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/${PROG}


### PR DESCRIPTION
The -D flag of install is not portable (for example,
it is not present in the FreeBSD version of the
utility). Use mkdir instead.