### PR TITLE
Add -P option to prepend relative image paths with a prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+config.mk
+pmenu

--- a/pmenu.1
+++ b/pmenu.1
@@ -58,6 +58,10 @@ Disable pointer warping when a new submenu spawns.
 This option is useful when using
 .B pmenu
 with a Wacom tablet.
+.TP
+.B \-P
+Prefix any relative paths given for images with this text.
+Must end with a '/' character.
 .PP
 Each item read from stdin has the following format:
 .IP

--- a/pmenu.c
+++ b/pmenu.c
@@ -1485,7 +1485,11 @@ run(struct Menu *rootmenu)
 			switch (ev.type) {
 			case Expose:
 				if (ev.xexpose.count == 0) {
-					if (currmenu->selected != NULL && ev.xexpose.window == currmenu->selected->tooltip) {
+					if (
+						currmenu &&
+						currmenu->selected != NULL &&
+						ev.xexpose.window == currmenu->selected->tooltip
+					) {
 						copytooltip(currmenu->selected);
 					} else if (currmenu && ev.xexpose.window == currmenu->win) {
 						copymenu(currmenu);

--- a/pmenu.c
+++ b/pmenu.c
@@ -51,7 +51,7 @@ static size_t path_prefix_size;
 static void
 usage(void)
 {
-	(void)fprintf(stderr, "usage: pmenu [-ptw] [-m modifier] [-r button]\n");
+	(void)fprintf(stderr, "usage: pmenu [-pw] [-m modifier] [-r button] [-P image_prefix]\n");
 	exit(1);
 }
 

--- a/pmenu.c
+++ b/pmenu.c
@@ -42,7 +42,7 @@ static int wflag = 0;           /* whether to disable pointer warping */
 static unsigned int button;     /* button to trigger pmenu in root mode */
 static unsigned int modifier;   /* modifier to trigger pmenu */
 
-static char *path_prefix = 0;
+static char *path_prefix = NULL;
 static size_t path_prefix_size;
 
 #include "config.h"
@@ -360,7 +360,7 @@ allocslice(const char *label, const char *output, char *file)
 	slice->label = label ? estrdup(label) : NULL;
 	if (!file) {
 		slice->file = NULL;
-	} else if (path_prefix && *file != '/') {
+	} else if (path_prefix && file[0] != '/' && !(file[0] == '.' && file[1] == '/')) {
 		slice->file = estrdup_prefix(file, path_prefix, path_prefix_size);
 	} else {
 		slice->file = estrdup(file);

--- a/pmenu.c
+++ b/pmenu.c
@@ -328,10 +328,7 @@ estrdup(const char *s)
 static char *
 estrdup_prefix(const char *s, const char *prefix, const size_t prefix_size)
 {
-	char *t = malloc(strlen(s) + prefix_size + 1);
-
-	if (!t)
-		err(1, "strdup_prefix");
+	char *t = emalloc(strlen(s) + prefix_size + 1);
 
 	strcpy(t, prefix);
 	strcpy(t + prefix_size, s);


### PR DESCRIPTION
Also makes -t option show an error, as it should, because it is an invalid option, and updates the `usage` function accordingly.

For an example of how this is useful, if before you wanted to do

```
pmenu <<! | sh
IMG:/home/user/Pictures/icons/firefox.png  firefox
IMG:/home/user/Pictures/icons/xterm.png   xterm
IMG:/home/user/Pictures/icons/urxvt.png   urxvt
IMG:/home/user/Pictures/icons/st.png      st
IMG:/home/user/Pictures/icons/poweroff.png poweroff
IMG:/home/user/Pictures/icons/reboot.png  reboot
!
```

now you can just do

```
pmenu -P /home/user/Pictures/icons/ <<! | sh
IMG:firefox.png  firefox
IMG:xterm.png   xterm
IMG:urxvt.png   urxvt
IMG:st.png      st
IMG:poweroff.png poweroff
IMG:reboot.png  reboot
!
```